### PR TITLE
Fix Celsius spelling

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -89,7 +89,7 @@ typedef struct {
 	int pin;
 } GPIO_t;
 
-// Temperature curve  19 .. 100 degrees celcius.
+// Temperature curve  19 .. 100 degrees Celsius.
 int T19_100[] = {
 	 220,   // 19 C
 	 232,  246,  257,  270,  280,  290,  305,  320,  340,  355,


### PR DESCRIPTION
## Summary
- correct spelling of "Celsius" in `main.c`

## Testing
- `grep -in celcius -R`

------
https://chatgpt.com/codex/tasks/task_e_68453f9f109c832c9cc0ee8f77a1e920